### PR TITLE
Empty lines issue fixed

### DIFF
--- a/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
+++ b/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.IO;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using IllyumL2T.Core.Parse;
+
+namespace IllyumL2T.Core.FieldsSplit.UnitTests
+{
+  [TestClass]
+  public class EmptyLinesIssueWithFileParser
+  {
+    const int HowManyOrders = 10;
+    const string OrdersFile = "OrdersWithEmptyLine.csv";
+    static IEnumerable<Order> _orders;
+
+    [ClassInitialize]
+    public static void InitializeClass(TestContext context)
+    {
+      var shipAddress = "Address A";
+      var dateTime = new DateTime(2010, 10, 10);
+
+      _orders = Enumerable.Range(1, HowManyOrders)
+                          .Select(counter => new Order()
+                          {
+                            OrderId = (short)counter,
+                            Freight = 1.1m,
+                            ShipAddress = shipAddress,
+                            DeliveryDate = dateTime
+                          });
+
+      var writeOrder = new Action<Order, TextWriter>((order,writer)=>
+      {
+        writer.WriteLine("{0}, {1:#0.00}, {2}, {3:dd/MM/yyyy}",
+                         order.OrderId,
+                         order.Freight,
+                         order.ShipAddress,
+                         order.DeliveryDate);
+      });
+
+      var ordersFilePath = Path.Combine(context.DeploymentDirectory, OrdersFile);
+      using (var writer = new StreamWriter(ordersFilePath))
+      {
+        foreach (var order in _orders.TakeWhile(order => order.OrderId <= HowManyOrders / 2))
+        {
+          writeOrder(order, writer);
+        }
+        writer.WriteLine(); //Empty line inserted in the middle of the order lines.
+        foreach (var order in _orders.TakeWhile(order => order.OrderId > HowManyOrders / 2))
+        {
+          writeOrder(order, writer);
+        }
+      }
+    }
+
+    public TestContext TestContext { get; set; }
+
+    [TestMethod]
+    public void ParseFileWithEmptyLineTest()
+    {
+      // Arrange
+      var ordersFilePath = Path.Combine(TestContext.DeploymentDirectory, OrdersFile);
+      using (var reader = new StreamReader(ordersFilePath))
+      {
+        var fileParser = new DelimiterSeparatedValuesFileParser<Order>();
+
+        // Act
+        var parseResults = fileParser.Read(reader, delimiter: ',', includeHeaders: false);
+
+        // Assert
+        Assert.IsTrue(_orders.SequenceEqual(parseResults.Select(parseResult => parseResult.Instance)));
+      }
+    }
+  }
+}

--- a/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
+++ b/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
@@ -49,7 +49,7 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
           writeOrder(order, writer);
         }
         writer.WriteLine(); //Empty line inserted in the middle of the order lines.
-        foreach (var order in _orders.TakeWhile(order => order.OrderId > HowManyOrders / 2))
+        foreach (var order in _orders.SkipWhile(order => order.OrderId <= HowManyOrders / 2))
         {
           writeOrder(order, writer);
         }

--- a/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
+++ b/IllyumL2T.Core.UnitTests/EmptyLinesIssueWithFileParser.cs
@@ -14,6 +14,7 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
   {
     const int HowManyOrders = 10;
     const string OrdersFile = "OrdersWithEmptyLine.csv";
+
     static IEnumerable<Order> _orders;
 
     [ClassInitialize]

--- a/IllyumL2T.Core.UnitTests/IllyumL2T.Core.UnitTests.csproj
+++ b/IllyumL2T.Core.UnitTests/IllyumL2T.Core.UnitTests.csproj
@@ -50,7 +50,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -62,6 +64,7 @@
     <Compile Include="DelimiterSeparatedValuesFileParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DelimiterSeparatedValuesFieldsSplitterTests.cs" />
+    <Compile Include="EmptyLinesIssueWithFileParser.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\IllyumL2T.Core\IllyumL2T.Core.csproj">

--- a/IllyumL2T.Core/Parse/DelimiterSeparatedValuesFileParser.cs
+++ b/IllyumL2T.Core/Parse/DelimiterSeparatedValuesFileParser.cs
@@ -19,32 +19,33 @@ namespace IllyumL2T.Core.Parse
 
     public IEnumerable<ParseResult<T>> Read(StreamReader reader, char delimiter, bool includeHeaders)
     {
-      if(reader == null)
+      if (reader == null)
       {
         throw new ArgumentNullException("StreamReader reader");
       }
 
       // If the file contains headers in the first row, simply skip those...
-      if(includeHeaders)
+      if (includeHeaders)
       {
         reader.ReadLine();
       }
 
       var fieldsSplitter = new DelimiterSeparatedValuesFieldsSplitter<T>(delimiter);
       var lineParser = new LineParser<T>(fieldsSplitter);
-      
-      while(true)
+
+      while (true)
       {
         var line = reader.ReadLine();
-        if(String.IsNullOrEmpty(line) == false)
-        {
-          var parseResult = lineParser.Parse(line);
-          yield return parseResult;
-        }
-        else
+        if (line == null) //This is the condition to finish the iteration. Based on http://msdn.microsoft.com/en-us/library/system.io.streamreader.readline(v=vs.110).aspx
         {
           yield break;
         }
+        if (String.IsNullOrWhiteSpace(line)) //An empty line is currently skipped and ignored.
+        {
+          continue;
+        }
+        var parseResult = lineParser.Parse(line);
+        yield return parseResult;
       }
     }
   }


### PR DESCRIPTION
@xxlxii 

Here is the Pull Request for EmptyLinesIssueFixed branch; which contains a unit test for a file with empty lines and the changes to the DelimiterSeparatedValuesFileParser.Read() method to make that test pass.

For reference, please notice that there is also the EmptyLinesIssue branch; which contains a failing unit test that demonstrates the reported issue.
