### PR TITLE
Updated IllyumL2T.Core.UnitTests: added cases for System.Boolean data type

### DIFF
--- a/IllyumL2T.Core.UnitTests/Classes for Testing/Bar.cs
+++ b/IllyumL2T.Core.UnitTests/Classes for Testing/Bar.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Globalization;
+
+namespace IllyumL2T.Core.FieldsSplit.UnitTests
+{
+  class Bar
+  {
+    public bool BooleanProperty { get; set; }
+    public bool? NullableBooleanProperty { get; set; }
+
+    public override bool Equals(object other)
+    {
+      if(other is Bar)
+      {
+        return ((Bar) other).GetHashCode() == this.GetHashCode(); 
+      }
+
+      return false;
+    }
+
+    public override int GetHashCode()
+    {
+      return BooleanProperty.GetHashCode() +
+             NullableBooleanProperty.GetHashCode();
+    }
+  }
+}

--- a/IllyumL2T.Core.UnitTests/Classes for Testing/Baz.cs
+++ b/IllyumL2T.Core.UnitTests/Classes for Testing/Baz.cs
@@ -3,16 +3,16 @@ using System.Globalization;
 
 namespace IllyumL2T.Core.FieldsSplit.UnitTests
 {
-  class Bar
+  class Baz
   {
     public bool BooleanProperty { get; set; }
     public bool? NullableBooleanProperty { get; set; }
 
     public override bool Equals(object other)
     {
-      if(other is Bar)
+      if(other is Baz)
       {
-        return ((Bar) other).GetHashCode() == this.GetHashCode(); 
+        return ((Baz) other).GetHashCode() == this.GetHashCode(); 
       }
 
       return false;

--- a/IllyumL2T.Core.UnitTests/FieldParserTests.cs
+++ b/IllyumL2T.Core.UnitTests/FieldParserTests.cs
@@ -731,7 +731,7 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
     {
       // Arrange
       var propertyName = "BooleanProperty";
-      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+      var propertyInfo = typeof(Baz).GetProperties().Single(p => p.Name == propertyName);
 
       // Act
       var fieldParser = new FieldParser(propertyInfo);
@@ -757,7 +757,7 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
     {
       // Arrange
       var propertyName = "BooleanProperty";
-      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+      var propertyInfo = typeof(Baz).GetProperties().Single(p => p.Name == propertyName);
 
       // Act
       var fieldParser = new FieldParser(propertyInfo);
@@ -773,7 +773,7 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
     {
       // Arrange
       var propertyName = "NullableBooleanProperty";
-      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+      var propertyInfo = typeof(Baz).GetProperties().Single(p => p.Name == propertyName);
 
       // Act
       var fieldParser = new FieldParser(propertyInfo);

--- a/IllyumL2T.Core.UnitTests/FieldParserTests.cs
+++ b/IllyumL2T.Core.UnitTests/FieldParserTests.cs
@@ -725,5 +725,63 @@ namespace IllyumL2T.Core.FieldsSplit.UnitTests
       Assert.IsNull(actual);
       Assert.IsFalse(fieldParser.Errors.Any());
     }
+
+    [TestMethod]
+    public void ParseBooleanUnparsableTest()
+    {
+      // Arrange
+      var propertyName = "BooleanProperty";
+      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+
+      // Act
+      var fieldParser = new FieldParser(propertyInfo);
+      var actual = fieldParser.Parse("1");
+
+      // Assert
+      Assert.IsNull(actual);
+
+      var expectedErrorCount = 1;
+      var actualErrorCount = fieldParser.Errors.Count();
+      Assert.AreEqual<int>(expectedErrorCount, actualErrorCount);
+
+      var expectedErrorMessage = String.Format("{0}: Unparsable {1} >>> {2}",
+                                               fieldParser.FieldName,
+                                               fieldParser.FieldType,
+                                               fieldParser.FieldInput);
+      var actualErrorMessage = fieldParser.Errors.Single();
+      Assert.AreEqual<string>(expectedErrorMessage, actualErrorMessage);
+    }
+
+    [TestMethod]
+    public void ParseBooleanTest()
+    {
+      // Arrange
+      var propertyName = "BooleanProperty";
+      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+
+      // Act
+      var fieldParser = new FieldParser(propertyInfo);
+      var actual = fieldParser.Parse($"  {System.Boolean.TrueString.ToLower()}  ");
+
+      // Assert
+      Assert.IsNotNull(actual);
+      Assert.IsFalse(fieldParser.Errors.Any());
+    }
+
+    [TestMethod]
+    public void ParseNullableBooleanTest()
+    {
+      // Arrange
+      var propertyName = "NullableBooleanProperty";
+      var propertyInfo = typeof(Bar).GetProperties().Single(p => p.Name == propertyName);
+
+      // Act
+      var fieldParser = new FieldParser(propertyInfo);
+      var actual = fieldParser.Parse(String.Empty);
+
+      // Assert
+      Assert.IsNull(actual);
+      Assert.IsFalse(fieldParser.Errors.Any());
+    }
   }
 }

--- a/IllyumL2T.Core.UnitTests/IllyumL2T.Core.UnitTests.csproj
+++ b/IllyumL2T.Core.UnitTests/IllyumL2T.Core.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Deterministic>true</Deterministic>
     <LangVersion>latest</LangVersion>
 


### PR DESCRIPTION
Test cases added to be explicit about current behavior for conventional values like '1' for System.Boolean data type.